### PR TITLE
会話リセット機能実装

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Send, RefreshCw } from 'lucide-react';
+import '../styles.css';
+import ResetChat from './ResetChat';
 import axios from 'axios';
 
 interface Message {
@@ -11,6 +13,7 @@ const Chat = () => {
     const [messages, setMessages] = useState<Message[]>([]);
     const [input, setInput] = useState('');
     const messagesEndRef = useRef<HTMLDivElement>(null);
+    const [showResetModal, setShowResetModal] = useState(false);
 
     // messageが変わったらメッセージの終わりにスクロールさせる処理
     useEffect(() => {
@@ -46,7 +49,11 @@ const Chat = () => {
         }
     };
     
-
+    const handleReset = () => {
+        setMessages([]);
+        setInput('');
+        setShowResetModal(false);
+    };
 
     return (
         <> {/* d-flexで flexboxを使い、flex-columnで縦方向に要素を並べる。 */}
@@ -58,7 +65,7 @@ const Chat = () => {
                             {messages.map((message, index) => (
                                 /* 配列messageをループ処理して1列ずつ要素(メッセージ)を表示するためのコンテナを表示していく。
                                 message.isUserが
-                                trueなら右端(justify-content-end)に要素を表示して、
+                                trueなら右端(justjify-content-end)に要素を表示して、
                                 falseなら左端(justify-content-start)に要素表示することで、
                                 ユーザーのメッセージと返事のメッセージを区別できるようにする。
                                 */
@@ -94,6 +101,7 @@ const Chat = () => {
                             className="btn btn-outline-secondary btn-lg"
                             style={{ height: '100px', width: '100px', flexShrink: 0 }}
                             disabled={messages.length === 0} // 配列messagesが空の時はリセットボタンを無効化
+                            onClick={() => setShowResetModal(true)} // ここでshowResetModalをtrueにすることでResetChat.tsxでdisplayにblockを適用し、モーダルウィンドウを表示
                         >
                             <RefreshCw size={60} />
                         </button>
@@ -131,7 +139,12 @@ const Chat = () => {
                 {/* ここまで入力部分 */}
             </div>
 
-
+            {/* リセットボタンクリック時にひらくモーダルウィンドウ */}
+            <ResetChat // showResetModalがtrueの時に表示されるコンポーネント(モーダルウィンドウ)
+                showResetModal={showResetModal} // showResetModalの値をshowResetModalに渡してPropsとしてResetChat.tsxに渡す(モーダルウィンドウの表示状態を制御するための状態変数を渡している)
+                setShowResetModal={setShowResetModal} // 関数setShowResetModalをsetShowResetModalに渡してPropsとしてResetChat.tsxに渡す(モーダルウィンドウの表示状態を更新するための関数を渡している)
+                handleReset={handleReset} // 関数handleResetをhandleResetに渡してPropsとしてResetChat.tsxに渡す(チャットをリセットするための関数を渡している)
+            />
         </>
     );
 };

--- a/src/components/ResetChat.tsx
+++ b/src/components/ResetChat.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+interface Props {
+    showResetModal: boolean;
+    setShowResetModal: (value: boolean) => void;
+    handleReset: () => void;
+}
+
+const ResetChat = ({ showResetModal, setShowResetModal, handleReset }: Props) => {
+    return (
+        <>
+            <div
+                className={`modal`}
+                style={{ display: showResetModal ? 'block' : 'none' }} // もし、showResetModalがtrueならモーダルウィンドウを表示
+            >
+                <div className="modal-dialog modal-dialog-centered modal-xl">
+                    <div className="modal-content bg-success-subtle" style={{ borderRadius: '40px' }}>
+                        <div className="modal-header border-bottom-0"> {/* モーダルウィンドウのヘッダー */}
+                            <h5 className="display-5 w-100 mt-5 ms-5">会話をリセットしますか？</h5>
+                        </div>
+                        <div className="modal-body"> {/* モーダルウィンドウのボディ */}
+                            <p className="display-6 ms-5">これまでの会話をリセットします。</p>
+                        </div>
+                        <div className="modal-footer border-top-0 d-flex justify-content-end"> {/* モーダルウィンドウのフッター */}
+                            <button
+                                type="button"
+                                className="btn btn-cancel fs-1 mb-5 me-3"
+                                style={{ borderRadius: '20px' }}
+                                onClick={() => setShowResetModal(false)}> {/* キャンセルボタンを押すとshowResetModalがfalseになりモーダルウィンドウが閉じる */}
+                                キャンセル
+                            </button> {/* キャンセルボタンを押すとshowResetModalがfalseになりモーダルウィンドウが閉じる */}
+                            <button
+                                type="button"
+                                className="btn btn-danger fs-1 fs-1 mb-5 ms-3 me-5"
+                                style={{ borderRadius: '20px' }}
+                                onClick={handleReset}> {/* リセットボタンを押すとChat.tsxのhandleResetが実行されて配列messages(会話の履歴)とinput(入力フォーム)の中身が空になる */}
+                                リセット
+                            </button> {/* リセットボタンを押したらhandleResetが実行されて配列messages(会話の履歴)とinput(入力フォーム)の中身が空になる */}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            {showResetModal && <div className="modal-backdrop show"></div>}
+        </>
+    );
+};
+
+export default ResetChat;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,5 @@
+/* Chat.tsx */
+.btn-cancel {
+    background-color: #bed9cd;
+    border-color: #9bbbad;
+}


### PR DESCRIPTION
<Chat.tsx>
会話リセット確認画面(モーダルウィンドウ)を別のコンポーネントに分けてインポートして表示。
会話履歴(message)と入力フォームの値(input)を消す関数(handleReset)の実装。
handleReset関数はあとでResetChat.tsxに移動させる。

<ResetChat.tsx>
会話リセット確認画面(モーダルウィンドウ)を別のコンポーネントに分けて新たに定義。

<styles.css>
ResetChat.tsxのキャンセルボタンのスタイルのために作った